### PR TITLE
Fix readme link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,4 +2,4 @@
 
 Welcome to the TBD GitHub. As a start, take a look at our [collaboration](https://github.com/TBD54566975/collaboration) repo.
 
-You can find our website [here at tbd.website](tbd.website).
+You can find our website at [tbd.website](https://tbd.website).


### PR DESCRIPTION
The original link tries navigating to "https://github.com/TBD54566975/.github/blob/main/tbd.website", which does not exist.