### PR TITLE
fix: use an absolute URI

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -2,4 +2,4 @@
 
 Welcome to the TBD GitHub. As a start, take a look at our [collaboration](https://github.com/TBD54566975/collaboration) repo.
 
-You can find our website [here at tbd.website](tbd.website).
+You can find our website [here at tbd.website](https://tbd.website).


### PR DESCRIPTION
```
fix: use an absolute URI

This change adds the use of the `https` protocol to an anchor link
pointing to `tbd.website`. The addition of the protocol turns the
relative reference into an absolute reference; without this, users
clicking the link from the organization's landing page [0] are
redirected to an incorrect URI [1] which results in a GitHub error page.

[0]: https://github.com/TBD54566975
[1]: https://github.com/TBD54566975/.github/blob/main/tbd.website
```
